### PR TITLE
Combine docstrings

### DIFF
--- a/multimethod.py
+++ b/multimethod.py
@@ -179,6 +179,31 @@ class multimethod(dict):
         while self.pending:
             func = self.pending.pop()
             self[get_types(func)] = func
+            
+    @property
+    def __doc__(self):
+        docs = []
+        if any([f.__doc__ is not None for f in set(self.values())]):
+            docs.append('Signatures with a docstring:')
+
+        other = []
+        for func in set(self.values()):
+            if func.__doc__:
+                s = f'{func.__name__}{inspect.signature(func)}'
+                s += '\n' + '-' * len(s)
+                s += '\n'.join([line.strip() for line in func.__doc__.split('\n')])
+                docs.append(s)
+            else:
+                other.append(f'{func.__name__}{inspect.signature(func)}')
+                
+        if other:
+            docs.append('Signatures without a docstring:\n    ' + '\n    '.join(other))
+            
+        return '\n\n'.join(docs)
+
+    @__doc__.setter
+    def __doc__(self, value):
+        pass
 
 
 class multidispatch(multimethod):

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -1,0 +1,24 @@
+from multimethod import multimethod
+
+
+@multimethod
+def foo(bar: int):
+    """
+    Argument is an integer
+    """
+    pass
+
+@multimethod
+def foo(bar: str):
+    """
+    Argument is a string
+    """
+    pass
+
+
+def test_docstring():
+    """
+    Test if multimethod collects its children's docstrings
+    """
+    assert "Argument is an integer" in foo.__doc__
+    assert "Argument is a string" in foo.__doc__


### PR DESCRIPTION
I copied the approach from the [multipledispatch](https://github.com/mrocklin/multipledispatch) library and quickly threw together an example of how the docstrings from the registered functions of a multimethod could be combined.

I'm not sure if this is the right approach here or if it messes up anything else, just thought it might be useful.

Fixes #8 