### PR TITLE
Employ function's inspect.Signature descriptor in liue of dunder __annotations__ for overload calls.

### DIFF
--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -257,9 +257,16 @@ class overload(collections.OrderedDict):
         """Dispatch to first matching function."""
         for sig, func in reversed(self.items()):
             arguments = sig.bind(*args, **kwargs).arguments
-            if all(predicate(arguments[name]) for name, predicate in func.__annotations__.items()):
+            if all(predicate(arguments[name]) for name, predicate in overload.__get_predicates(sig.parameters)):
                 return func(*args, **kwargs)
         raise DispatchError("No matching functions found")
+
+    @staticmethod
+    def __get_predicates(parameters):
+        for name, parameter in parameters.items():
+            annotation = parameter.annotation
+            if annotation is not inspect.Parameter.empty:
+                yield name, annotation
 
     def register(self, func: Callable) -> Callable:
         """Decorator for registering a function."""


### PR DESCRIPTION
Overload call relies on function's `__annotations__` to make up a list of predicates for arguments matching. Yet `__annotations__` also includes `return` annotation if present, that should not provide a basis for the argument predicate list.
The pull request replaces `__annotations__` with more descriptive `inspect.Signature.parameters`, that is comprised of function arguments exclusively. That approach also solves the #14 issue.