### PR TITLE
fix: Allow parameters annotated with meta-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ dev
 * Variable-length tuples of homogeneous type
 * Ignore default and keyword arguments
 * Resolved ambiguous `Union` types
+* Resolved dispatch errors when annotating parameters with meta-types such as `type`
 
 1.4
 

--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -96,7 +96,7 @@ def distance(cls, subclass):
     """Return estimated distance between classes for tie-breaking."""
     if getattr(cls, '__origin__', None) is typing.Union:
         return min(distance(arg, subclass) for arg in cls.__args__)
-    mro = subclass.mro()
+    mro = type.mro(subclass)
     return mro.index(cls if cls in mro else object)
 
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,3 +1,5 @@
+import enum
+
 import pytest
 from typing import Any, AnyStr, Dict, Iterable, List, Tuple, TypeVar, Union
 from multimethod import (
@@ -84,6 +86,13 @@ def test_signature():
     assert signature([list]) <= signature([List[int]])
     assert signature([List[int]]) - signature([list])
     assert signature([list]) - signature([List[int]]) == (1,)
+
+    # with metaclasses:
+    assert signature([type]) - signature([type]) == (0,)
+    assert signature([type]) - signature([object]) == (1,)
+    # using EnumMeta because it is a standard, stable, metaclass
+    assert signature([enum.EnumMeta]) - signature([object]) == (2,)
+    assert signature([Union[type, enum.EnumMeta]]) - signature([object]) == (1,)
 
 
 def test_get_type():

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -236,3 +236,27 @@ def test_ellipsis():
         func(())
     with pytest.raises(DispatchError):
         func(((0, 1.0),))
+
+
+def test_meta_types():
+    @multimethod
+    def f(x):
+        return "object"
+
+    @f.register
+    def f(x: type):
+        return "type"
+
+    @f.register
+    def f(x: enum.EnumMeta):
+        return "enum"
+
+    @f.register
+    def f(x: enum.Enum):
+        return "member"
+
+    dummy_enum = enum.Enum("DummyEnum", names="SPAM EGGS HAM")
+    assert f(123) == "object"
+    assert f(int) == "type"
+    assert f(dummy_enum) == "enum"
+    assert f(dummy_enum.EGGS) == "member"


### PR DESCRIPTION
This should cover most cases, but maybe I should add more tests.

Closes #25