### PR TITLE
fix: Check that homonym is a multimethod when getting the base multimethod object

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ dev
 * Variable-length tuples of homogeneous type
 * Ignore default and keyword arguments
 * Resolved ambiguous `Union` types
+* Fixed an issue with name collision when defining a multimethod
 
 1.4
 

--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -129,7 +129,8 @@ class multimethod(dict):
         self = functools.update_wrapper(dict.__new__(cls), func)
         self.pending = set()
         self.get_type = type  # default type checker
-        return namespace.get(func.__name__, self)
+        homonym = namespace.get(func.__name__, self)
+        return homonym if isinstance(homonym, multimethod) else self
 
     def __init__(self, func: Callable):
         try:

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -227,3 +227,21 @@ def test_ellipsis():
         func(())
     with pytest.raises(DispatchError):
         func(((0, 1.0),))
+
+
+def test_name_shadowing():
+    # an object with the same name appearing previously in the same namespace
+    temp = 123  # noqa
+
+    # a multimethod shadowing that name
+    @multimethod
+    def temp(x: int):  # noqa
+        return "int"
+
+    @multimethod
+    def temp(x: float):
+        return "float"
+
+    assert isinstance(temp, multimethod)
+    assert temp(0) == "int"
+    assert temp(0.0) == "float"


### PR DESCRIPTION
This fixes an issue where a new multimethod whose name collides with an unrelated variable
or function in the same namespace would return that as the result of the decoration.