### PR TITLE
Improve dispatch exception handling

### DIFF
--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -206,7 +206,11 @@ class multimethod(dict):
 
     def __call__(self, *args, **kwargs):
         """Resolve and dispatch to best method."""
-        return self[tuple(map(self.get_type, args))](*args, **kwargs)
+        func = self[tuple(map(self.get_type, args))]
+        try:
+            return func(*args, **kwargs)
+        except TypeError as ex:
+            raise DispatchError("Function {func.__code__}") from ex
 
     def evaluate(self):
         """Evaluate any pending forward references.

--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -210,7 +210,7 @@ class multimethod(dict):
         try:
             return func(*args, **kwargs)
         except TypeError as ex:
-            raise DispatchError("Function {func.__code__}") from ex
+            raise DispatchError("Function {func.__code__}".format(func=func)) from ex
 
     def evaluate(self):
         """Evaluate any pending forward references.

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -278,3 +278,17 @@ def test_name_shadowing():
     assert isinstance(temp, multimethod)
     assert temp(0) == "int"
     assert temp(0.0) == "float"
+
+
+def test_dispatch_exception():
+    @multimethod
+    def temp(x: int):  # noqa
+        return "int"
+
+    @multimethod
+    def temp(x: float):  # noqa
+        return "float"
+
+    with pytest.raises(DispatchError, match="file.*line"):
+        # invalid number of args
+        temp(1, 1)

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -289,6 +289,6 @@ def test_dispatch_exception():
     def temp(x: float):  # noqa
         return "float"
 
-    with pytest.raises(DispatchError, match="file.*line"):
-        # invalid number of args
+    with pytest.raises(DispatchError, match="test_methods.py"):
+        # invalid number of args, check source file is part of the exception args
         temp(1, 1)


### PR DESCRIPTION
While developing a non-trivial library, it can be hard to pinpoint exactly what function is giving `TypeError` due to extra/missing args. This PR add `TypeError`s to a `DispatchError` chain that prints the file/lineno that raised the error.