### PR TITLE
Fix partial ordering, kwargs behavior and associated tests

### DIFF
--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -28,8 +28,8 @@ def get_types(func: Callable) -> tuple:
         type_hints.get(param.name, object)
         for param in inspect.signature(func).parameters.values()
         if param.default is param.empty and param.kind in positionals
-    ]  # missing annotations are padded with `object`, but trailing objects are unnecessary
-    return tuple(itertools.dropwhile(lambda cls: cls is object, reversed(annotations)))[::-1]
+    ]  # missing annotations are padded with `object`
+    return tuple(annotations)
 
 
 class DispatchError(TypeError):
@@ -112,7 +112,7 @@ class signature(tuple):
         return tuple.__new__(cls, map(subtype, types))
 
     def __le__(self, other) -> bool:
-        return len(self) <= len(other) and all(map(issubclass, other, self))
+        return len(other) <= len(self) and all(map(issubclass, other, self))
 
     def __lt__(self, other) -> bool:
         return self != other and self <= other
@@ -242,7 +242,7 @@ class multidispatch(multimethod):
 
 get_type = multimethod(type)
 get_type.__doc__ = """Return a generic `subtype` which checks subscripts."""
-for atomic in (Iterator, str, bytes):
+for atomic in (Iterator, str, bytes, object):
     get_type[(atomic,)] = type
 
 

--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -21,7 +21,13 @@ def groupby(func: Callable, values: Iterable) -> dict:
 def get_types(func: Callable) -> Iterable[tuple]:
     """Return evaluated type hints for positional required parameters in order.
 
-    If `func` has optional kwargs yield multiple type signatures
+    If `func` has optional kwargs yield multiple type signatures. Example:
+
+    ```
+    def foo(a, b=1):
+        ...
+
+    assert get_types(foo) == [(object, object), (object,)]
     """
 
     if not hasattr(func, '__annotations__'):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -145,7 +145,7 @@ def test_varargs():
 
     @multimethod
     def varg2(a):
-        return "single"
+        return "fallback"
 
     @multimethod
     def varg2(*args, **kwargs):
@@ -153,11 +153,31 @@ def test_varargs():
 
     @multimethod
     def varg2(a: int, *args, **kwargs):
-        return "mixed"
+        return "int"
 
-    assert varg2("a") == "single"
+    @multimethod
+    def varg2(a: float, *args, b: str = "foo", **kwargs):
+        return "float"
+
+    @multimethod
+    def varg2(a: tuple, b: str = "foo", **kwargs):
+        return "tuple"
+
+    assert varg2("a") == "fallback"
     assert varg2("a", 2) == "var"
-    assert varg2(1, 2) == "mixed"
+    assert varg2(1, 2) == "int"
+
+    assert varg2(1.0) == "float"
+    assert varg2(1.0, b="bar") == "float"
+    assert varg2(1.0, "bar") == "float"
+    assert varg2(1.0, True) == "float"
+
+    assert varg2((), "bar") == "tuple"
+    assert varg2((), "bar", c=1) == "tuple"
+
+    # inconsistent behavior below expected since kwargs are not part of dispatch logic
+    assert varg2((), 1.0) == "var"
+    assert varg2((), b=1.0) == "tuple"
 
 
 def test_div():

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -119,8 +119,20 @@ def test_kwargs():
         pass
 
     @multimethod
-    def temp(a, b=1):
+    def temp(a, b=1, **kwargs):
         return f"a={a} b={b}"
 
     assert temp(1) == "a=1 b=1"
     assert temp(1, 2) == "a=1 b=2"
+    assert temp(1, b=3, c=1) == "a=1 b=3"
+
+
+def test_div():
+    from multimethod import multimethod
+    import operator
+
+    classic_div = multimethod(operator.truediv)
+    classic_div[int, int] = operator.floordiv
+
+    classic_div(3, 2)
+    classic_div(3.0, 2)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -86,7 +86,8 @@ def test_arguments():
 
     if sys.version_info >= (3, 8):
         exec("def func(a, b: int, /, c: int, d, e: int = 0, *, f: int): pass")
-    assert get_types(func) == (object, int, int, object)
+    got = list(get_types(func))
+    assert got == [(object, int, int, object, int), (object, int, int, object)]
 
 
 def test_nargs_precedence():
@@ -111,3 +112,15 @@ def test_nargs_precedence():
     assert temp(1) == "fallback"
     assert temp(Foo(), False) == "2 args"
     assert temp(Foo()) == "1 arg"
+
+
+def test_kwargs():
+    class Foo:
+        pass
+
+    @multimethod
+    def temp(a, b=1):
+        return f"a={a} b={b}"
+
+    assert temp(1) == "a=1 b=1"
+    assert temp(1, 2) == "a=1 b=2"

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -289,6 +289,8 @@ def test_dispatch_exception():
     def temp(x: float):  # noqa
         return "float"
 
-    with pytest.raises(DispatchError, match="test_methods.py"):
+    with pytest.raises(DispatchError, match="Function"):
         # invalid number of args, check source file is part of the exception args
-        temp(1, 1)
+        temp(1, foo=1)
+
+

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -292,5 +292,3 @@ def test_dispatch_exception():
     with pytest.raises(DispatchError, match="test_methods.py"):
         # invalid number of args, check source file is part of the exception args
         temp(1, foo=1)
-
-

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -289,7 +289,7 @@ def test_dispatch_exception():
     def temp(x: float):  # noqa
         return "float"
 
-    with pytest.raises(DispatchError, match="Function"):
+    with pytest.raises(DispatchError, match="test_methods.py"):
         # invalid number of args, check source file is part of the exception args
         temp(1, foo=1)
 


### PR DESCRIPTION
Scenario giving dispatch error:

```py
def test_nargs_precedence():
    class AbstractFoo:
        pass

    class Foo(AbstractFoo):
        pass

    @multimethod
    def temp(a):
        return "fallback"

    @multimethod
    def temp(a: AbstractFoo, b: bool):
        return "2 args"

    @multimethod
    def temp(a: Foo):
        return "1 arg"

    assert temp(1) == "fallback"
    assert temp(Foo(), False) == "2 args"
    assert temp(Foo()) == "1 arg"
```

The equivalent Julia dispatch works as stated in the scenario above.

The actual fix changed the semantic of partial ordering in `signature.__le__` (line: 115); ie. not should never dispatch on a function with `len(signature_args) != len(call_positional_args)`. From Julia dev docs, this is the actual behavior of the dispatch logic.

The side-effect was no longer handling `POSITIONAL_OR_KEYWORD` and `VAR_POSITIONAL` properly. I added a bunch of tests to further stress the scenarios.

I adapted `get_types` returning an iterable of signatures, eg. both `(object, object)` and `(object,)` when it encounters a `POSITIONAL_OR_KEYWORD`. This solution [mimics the Julia solution (https://docs.julialang.org/en/v1/manual/functions/#Optional-Arguments). For variadic positional args, the solution was to return a variadic argument marker, then expand the signature arguments, padding with `object`s as needed. 

Fixed tests for internal checks where needed.