### PR TITLE
Python 3.11 supported.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-beta - 3.11']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ class Foo:
 ```
 
 ## Changes
+dev
+
+* Python 3.11 supported
+
 1.8
 
 * `Callable` checks parameters and return type

--- a/multimethod/__init__.py
+++ b/multimethod/__init__.py
@@ -71,14 +71,14 @@ class subtype(type):
         if isinstance(self.__origin__, abc.ABCMeta):
             self.__origin__.register(self)
 
-    def __getstate__(self) -> tuple:
+    def _getstate(self) -> tuple:
         return self.__origin__, self.__args__
 
     def __eq__(self, other) -> bool:
-        return hasattr(other, '__origin__') and self.__getstate__() == subtype.__getstate__(other)
+        return hasattr(other, '__origin__') and self._getstate() == subtype._getstate(other)
 
     def __hash__(self) -> int:
-        return hash(self.__getstate__())
+        return hash(self._getstate())
 
     def __subclasscheck__(self, subclass: type) -> bool:
         origin = getattr(subclass, '__origin__', subclass)


### PR DESCRIPTION
Renamed `__getstate__` to avoid a conflict with how the method is called in 3.11.