### PR TITLE
Bugfix/multidispatch on kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .coverage
 site/
+.idea/

--- a/README.md
+++ b/README.md
@@ -107,7 +107,52 @@ def func(obj: str.isdigit):
 ```
 
 ### multidispatch
-`multidispatch` is a wrapper to provide compatibility with `functools.singledispatch`. It requires a base implementation and use of the `register` method instead of namespace lookup. It also provisionally supports dispatching on keyword arguments.
+`multidispatch` allows one to dispatch based on all the provided arguments (positional and keyword).
+
+Usage:
+```python
+from multimethod import multidispatch
+
+@multidispatch
+def func(left, right):
+    return left + right
+
+@func.register(int, float)
+@func.register(float, int)
+def _(left, right):
+    return (left + right) / 2
+
+print(func(1, 2))  # 3
+print(func(1.0, 2.0))  # 3
+
+print(func(1.0, 2))  # 1.5
+print(func(1, 2.0))  # 1.5
+
+print(func(right=1, left=2.0))  # 1.5
+print(func(1, left=2.0))  # 1.5
+print(func(1, right=2.0))  # 1.5
+```
+
+#### Known limitations:
+- if an argument of your method isn't type hinted, it will match everything.
+- matching happens from left to right.
+```python
+from multimethod import multidispatch
+
+
+@multidispatch
+def func(a, b):
+    return 1
+
+@func.register
+def _(a, b: float = 1.0, c: str = "A"):
+    return 2
+
+
+print(func(1, 2))  # 1
+print(func(1, "A"))  # 1
+```
+The last bit happens because "A" is matched with `b`, which should be a float. Maybe an adjustment is needed in this case?
 
 ### multimeta
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -6,62 +6,6 @@ import pytest
 from multimethod import get_types, multidispatch, multimethod, signature, DispatchError
 
 
-def test_signature():
-    with pytest.raises(TypeError):
-        signature([list]) <= signature([None])
-
-
-# roshambo
-class rock: pass
-
-class paper: pass
-
-class scissors: pass
-
-
-@multimethod
-def roshambo(left, right):
-    return 'tie'
-
-
-@roshambo.register(scissors, rock)
-@roshambo.register(rock, scissors)
-def _(left, right):
-    return 'rock smashes scissors'
-
-
-@roshambo.register(paper, scissors)
-@roshambo.register(scissors, paper)
-def _(left, right):
-    return 'scissors cut paper'
-
-
-@roshambo.register(rock, paper)
-@roshambo.register(paper, rock)
-def _(left, right):
-    return 'paper covers rock'
-
-
-def test_roshambo():
-    assert roshambo.__name__ == 'roshambo'
-    r, p, s = rock(), paper(), scissors()
-    assert len(roshambo) == 7
-    assert roshambo(r, p) == 'paper covers rock'
-    assert roshambo(p, r) == 'paper covers rock'
-    assert roshambo(r, s) == 'rock smashes scissors'
-    assert roshambo(p, s) == 'scissors cut paper'
-    assert roshambo(r, r) == 'tie'
-    assert len(roshambo) == 8
-    del roshambo[()]
-    del roshambo[rock, paper]
-    assert len(roshambo) == 5
-    with pytest.raises(DispatchError, match="0 methods"):
-        roshambo(r, r)
-    r = roshambo.copy()
-    assert isinstance(r, multimethod)
-    assert r == roshambo
-
-
 def test_cls():
     class cls:
         method = multidispatch(lambda self, other: None)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,5 +1,7 @@
 from collections.abc import Iterable
 from concurrent import futures
+from typing import Union
+
 import pytest
 from multimethod import get_types, multidispatch, multimethod, signature, DispatchError
 
@@ -10,7 +12,11 @@ def test_signature():
 
 
 # roshambo
-rock, paper, scissors = (type('', (), {}) for _ in range(3))
+class rock: pass
+
+class paper: pass
+
+class scissors: pass
 
 
 @multimethod
@@ -56,28 +62,24 @@ def test_roshambo():
     assert r == roshambo
 
 
-# methods
-class cls(object):
-    method = multidispatch(lambda self, other: None)
-
-    @method.register(Iterable, object)
-    def _(self, other):
-        return 'left'
-
-    @method.register(object, Iterable)
-    def _(self, other):
-        return 'right'
-
-
 def test_cls():
+    class cls:
+        method = multidispatch(lambda self, other: None)
+
+        @method.register
+        def iterable_object(self: Iterable, other: object):
+            return 'left'
+
+        @method.register
+        def object_iterable(self: object, other: Iterable):
+            return 'right'
+
     obj = cls()
     assert obj.method(None) is cls.method(None, None) is None
     assert obj.method('') == 'right'
     assert cls.method('', None) == 'left'
     with pytest.raises(DispatchError, match="2 methods"):
         cls.method('', '')
-    cls.method[object, Iterable] = cls.method[Iterable, object]
-    assert cls.method('', '') == 'left'
 
 
 def test_arguments():
@@ -90,18 +92,66 @@ def test_arguments():
 def test_keywords():
     @multidispatch
     def func(arg):
-        pass
+        return 0
 
     @func.register
-    def _(arg: int):
-        return int
+    def only_int(arg: int):
+        return 1
 
     @func.register
-    def _(arg: int, extra: float):
-        return int
+    def int_and_union(arg: int, extra: Union[int, float]):
+        return 2
 
-    assert func(0) is func(arg=0) is int
-    assert multidispatch(bool)(1)
+    @func.register
+    def int_str(arg: int, extra: str):
+        return 3
+
+    @func.register
+    def int_kwonly(arg: int, *, extra: rock):
+        return 4
+
+    assert func("sth") == 0
+    assert func(0) == func(arg=0) == 1
+    assert func(0, 0.0) == func(arg=0, extra=0.0) == func(arg=0, extra=0.0) == 2
+    assert func(0, 0) == func(0, extra=0) == func(arg=0, extra=0) == 2
+    assert func(0, '') == func(0, extra='') == func(arg=0, extra='') == 3
+    assert func(0, extra=rock()) == func(arg=0, extra=rock()) == 4
+
+    with pytest.raises(DispatchError):
+        func(0, rock())
+
+
+def test_keywords2():
+    """Check what happens if you get an undeclared type."""
+
+    @multidispatch
+    def func(arg: int, extra: int):
+        return 1
+
+    @func.register()
+    def int_str(arg: int, extra: str):
+        return 2
+
+    assert func(0, 0) == 1
+    assert func(0, "") == 2
+    with pytest.raises(DispatchError, match="No matching functions found"):
+        func(0, tuple())
+
+
+def test_keywords3():
+    """Check what happens if the function signature doesn't match."""
+
+    @multidispatch
+    def func(arg: int, extra: int):
+        return 1
+
+    @func.register()
+    def int_str(arg: int, *, extra: str):
+        return 2
+
+    assert func(0, 0) == 1
+    with pytest.raises(DispatchError, match="No matching functions found"):
+        func(0, "")
 
 
 def test_concurrency():
@@ -113,3 +163,156 @@ def test_concurrency():
     args = [type('', (int,), {})() for _ in range(500)]
     fs = [submit(func, arg) for arg in args]
     assert all(future.result() is None for future in fs)
+
+
+# Test methods below are based on the 'overload' tests of Richard Jones:
+# https://pypi.org/project/overload/
+def test_wrapping():
+    """check that we generate a nicely-wrapped result"""
+
+    @multidispatch
+    def func(arg):
+        'doc'
+        pass
+
+    @func.register
+    def func(*args):
+        'doc2'
+        pass
+
+    assert func.__doc__ == 'doc'
+
+
+def test_var_positional():
+    """Check that we can overload instance methods with variable positional arguments."""
+
+    class cls:
+        @multidispatch
+        def func(self):
+            return 1
+
+        @func.register()
+        def func(self, *args: object):
+            return 2
+
+    assert cls().func() == 1
+    assert cls().func(1) == 2
+
+
+def test_arg_pattern():
+    @multidispatch
+    def func(a):
+        return 1
+
+    @func.register
+    def a_b(a, b):
+        return 2
+
+    assert func('a') == 1
+    assert func('a', 'b') == 2
+
+    with pytest.raises(DispatchError, match="No matching functions found"):
+        func()
+
+    with pytest.raises(DispatchError, match="No matching functions found"):
+        func('a', 'b', 'c')
+
+    with pytest.raises(DispatchError, match="No matching functions found"):
+        func(b=1)
+
+
+def test_two_multidispatches_are_independent():
+    class cls1:
+        @multidispatch
+        def func(self):
+            return 1
+
+    class cls2:
+        @multidispatch
+        def func(self):
+            return 2
+
+    assert cls1().func() == 1
+    assert cls2().func() == 2
+
+
+def test_correct_dispatching_based_on_type():
+    @multidispatch
+    def func(a: int):
+        return 1
+
+    @func.register
+    def a_as_str(a: str):
+        return 2
+
+    assert func(1) == 1
+    assert func('1') == 2
+
+
+def test_varargs():
+    @multidispatch
+    def func(a):
+        return 1
+
+    @func.register
+    def var_args(*args):
+        return 100 + len(args)
+
+    assert func(1) == 1
+    assert func(1, 2) == 102
+
+
+def test_varargs_mixed():
+    @multidispatch
+    def func(a):
+        return 'a'
+
+    @func.register
+    def a_with_varargs(a, *args):
+        return '*args {}'.format(len(args))
+
+    assert func(1) == 'a'
+    assert func(1, 2) == '*args 1'
+    assert func(1, 2, 3) == '*args 2'
+
+
+def test_kw():
+    @multidispatch
+    def func(a):
+        return 'a'
+
+    @func.register
+    def kwargs(**kw):
+        return '**kw {}'.format(len(kw))
+
+    assert func(1) == 'a'
+    assert func(a=1) == 'a'
+    assert func(a=1, b=2) == '**kw 2'
+
+
+def test_kw_mixed():
+    @multidispatch
+    def func(a):
+        return 'a'
+
+    @func.register
+    def a_with_kwargs(a, **kw):
+        return '**kw {}'.format(len(kw))
+
+    assert func(1) == 'a'
+    assert func(a=1) == 'a'
+    assert func(a=1, b=2) == '**kw 1'
+
+
+def test_kw_mixed2():
+    @multidispatch
+    def func(a):
+        return 'a'
+
+    @func.register
+    def c_with_kwargs(c=1, **kw):
+        return '**kw {}'.format(len(kw))
+
+    assert func(1) == 'a'
+    assert func(a=1) == 'a'
+    assert func(c=1, b=2) == '**kw 1'

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,8 @@
+import pytest
+
+from multimethod import signature
+
+
+def test_signature():
+    with pytest.raises(TypeError):
+        signature([list]) <= signature([None])

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -299,3 +299,54 @@ def test_dispatch_exception():
         return "optional"
 
     assert temp(True, 1.0) == "optional"
+
+
+# roshambo
+class rock: pass
+
+class paper: pass
+
+class scissors: pass
+
+
+@multimethod
+def roshambo(left, right):
+    return 'tie'
+
+
+@roshambo.register(scissors, rock)
+@roshambo.register(rock, scissors)
+def _(left, right):
+    return 'rock smashes scissors'
+
+
+@roshambo.register(paper, scissors)
+@roshambo.register(scissors, paper)
+def _(left, right):
+    return 'scissors cut paper'
+
+
+@roshambo.register(rock, paper)
+@roshambo.register(paper, rock)
+def _(left, right):
+    return 'paper covers rock'
+
+
+def test_roshambo():
+    assert roshambo.__name__ == 'roshambo'
+    r, p, s = rock(), paper(), scissors()
+    assert len(roshambo) == 7
+    assert roshambo(r, p) == 'paper covers rock'
+    assert roshambo(p, r) == 'paper covers rock'
+    assert roshambo(r, s) == 'rock smashes scissors'
+    assert roshambo(p, s) == 'scissors cut paper'
+    assert roshambo(r, r) == 'tie'
+    assert len(roshambo) == 8
+    del roshambo[()]
+    del roshambo[rock, paper]
+    assert len(roshambo) == 5
+    with pytest.raises(DispatchError, match="0 methods"):
+        roshambo(r, r)
+    r = roshambo.copy()
+    assert isinstance(r, multimethod)
+    assert r == roshambo


### PR DESCRIPTION
Hi @coady,

I had an issue at work that keyword arguments were not properly matched, so I was diving into the matching engine for the full signature. As `multimethod` only matches on positional arguments, you hinted that I should use `multidispatch`, but also that one fell short of what I needed.

Hence I tried to look at other libraries, but seems not much in the market for this kind of routing.
I found one called `overload`, which was nearly what I needed it to do. So I took the tests and fixed the code so these tests could run through the new `multidispatch` code.

BTW, the only class I touched is `multidispatch`. (and I moved some `multimethod` tests to the `test_method` file as they belong there imho.

I want to raise this PR to get your idea about what I did and to get some pointers on how to improve on it.

One thing I'm not very certain about is what I also mentioned in the README:
```python
from multimethod import multidispatch


@multidispatch
def func(a, b):
    return 1

@func.register
def _(a, b: float = 1.0, c: str = "A"):
    return 2


print(func(1, 2))  # 1
print(func(1, "A"))  # 1
```
The last bit happens because "A" is matched with `b`, which should be a float.
This is because I'm using the Signature.bind method, but that obviously doesn't take into account the type hintings...

If a full blown matching engine needs to be implemented that might lead too far and will slow things down considerably.
So I don't know if it's truly worth the effort to do this now.

At least the basics work: match ANY signature, with ANY kind of arguments.

Let's discuss :)